### PR TITLE
FIXED: SSL_TLS Modules response handeling

### DIFF
--- a/src/nettacker/core/lib/socket.py
+++ b/src/nettacker/core/lib/socket.py
@@ -316,7 +316,7 @@ class SocketEngine(BaseEngine):
             return response
 
         if sub_step["method"] in {"ssl_certificate_scan", "ssl_version_scan"}:
-            if response["ssl_flag"]:
+            if response and response["ssl_flag"]:
                 for condition in conditions:
                     if (conditions[condition]["reverse"] and not response[condition]) or (
                         not conditions[condition]["reverse"] and response[condition]

--- a/src/nettacker/core/lib/socket.py
+++ b/src/nettacker/core/lib/socket.py
@@ -9,12 +9,13 @@ import socket
 import ssl
 import struct
 import time
+from datetime import datetime, timezone
 
-from core.utils.common import is_weak_hash_algo
-
-from core.utils.common import reverse_and_regex_condition
+from core.utils.common import is_weak_hash_algo, reverse_and_regex_condition
+from OpenSSL import crypto
 
 from nettacker.core.lib.base import BaseEngine, BaseLibrary
+from nettacker.core.utils.common import check_ssl_version, check_cipher_suite
 
 log = logging.getLogger(__name__)
 
@@ -83,46 +84,34 @@ class SocketLibrary(BaseLibrary):
         }
 
     def ssl_certificate_scan(self, host, port, timeout):
-        from OpenSSL import crypto
-        from datetime import datetime, timezone
         tcp_socket = create_tcp_socket(host, port, timeout)
         if tcp_socket is None:
             return None
+
         socket_connection, ssl_flag = tcp_socket
         peer_name = socket_connection.getpeername()
-        if(ssl_flag):
-            expired = False
-            expiring_soon = False
-            self_signed = False
+        if ssl_flag:
             cert = ssl.get_server_certificate((host, port))
             x509 = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
             weak_signing_algo = is_weak_hash_algo(str(x509.get_signature_algorithm()))
-            cert_expires = datetime.strptime(x509.get_notAfter().decode('utf-8'), '%Y%m%d%H%M%S%z')
-            num_days = (cert_expires - datetime.now(timezone.utc)).days
-            if(num_days<=30):
-                expiring_soon = True
-            if(x509.has_expired() == True):
-                expired = True
-            if x509.get_issuer() == x509.get_subject():
-                self_signed = True
-            return{
-                "self_signed": self_signed,
-                "expired": expired,
+            cert_expires = datetime.strptime(x509.get_notAfter().decode("utf-8"), "%Y%m%d%H%M%S%z")
+
+            return {
+                "self_signed": x509.get_issuer() == x509.get_subject(),
+                "expired": x509.has_expired(),
                 "weak_signing_algo": weak_signing_algo,
                 "ssl_flag": ssl_flag,
                 "peer_name": peer_name,
-                "expiring_soon": expiring_soon,
-                "service": socket.getservbyport(int(port))
+                "expiring_soon": (cert_expires - datetime.now(timezone.utc)).days < 30,
+                "service": socket.getservbyport(int(port)),
             }
-        return{
+        return {
             "peer_name": peer_name,
             "ssl_flag": ssl_flag,
-            "service": socket.getservbyport(int(port))
+            "service": socket.getservbyport(int(port)),
         }
 
     def ssl_version_scan(self, host, port, timeout):
-        from nettacker.core.utils.common import check_ssl_version, check_cipher_suite
-
         tcp_socket = create_tcp_socket(host, port, timeout)
         if tcp_socket is None:
             return None
@@ -130,22 +119,25 @@ class SocketLibrary(BaseLibrary):
         socket_connection, ssl_flag = tcp_socket
         bad_cipher_suite = False
         peer_name = socket_connection.getpeername()
-        if(ssl_flag):
+
+        if ssl_flag:
             ssl_ver = socket_connection.version()
             bad_version = check_ssl_version(ssl_ver)
-            if(ssl_ver != "TLSv1.3"): bad_cipher_suite = check_cipher_suite(host, port, timeout)
-            return{
+            if ssl_ver != "TLSv1.3":
+                bad_cipher_suite = check_cipher_suite(host, port, timeout)
+            return {
                 "ssl_version": ssl_ver,
                 "bad_version": bad_version,
                 "bad_cipher_suite": bad_cipher_suite,
                 "ssl_flag": ssl_flag,
                 "peer_name": peer_name,
-                "service": socket.getservbyport(int(port))
+                "service": socket.getservbyport(int(port)),
             }
-        return{
+
+        return {
             "ssl_flag": ssl_flag,
             "service": socket.getservbyport(int(port)),
-            "peer_name": peer_name
+            "peer_name": peer_name,
         }
 
     def socket_icmp(self, host, timeout):
@@ -323,11 +315,12 @@ class SocketEngine(BaseEngine):
         if sub_step["method"] == "socket_icmp":
             return response
 
-        if sub_step["method"] == "ssl_certificate_scan" or sub_step["method"] == "ssl_version_scan":
+        if sub_step["method"] in {"ssl_certificate_scan", "ssl_version_scan"}:
             if response:
                 for condition in conditions:
-                    if( (conditions[condition]["reverse"] and response[condition] == False) \
-                     or (conditions[condition]["reverse"] == False and response[condition]) ):
+                    if (conditions[condition]["reverse"] and not response[condition]) or (
+                        not conditions[condition]["reverse"] and response[condition]
+                    ):
                         condition_results[condition] = True
 
                 if condition_type == "and":

--- a/src/nettacker/core/module.py
+++ b/src/nettacker/core/module.py
@@ -45,7 +45,13 @@ class Module:
         self.skip_service_discovery = options.skip_service_discovery
 
         self.discovered_services = None
-        self.ignored_core_modules = ["subdomain_scan", "icmp_scan", "port_scan", "ssl_certificate_scan", "ssl_version_scan"]
+        self.ignored_core_modules = [
+            "subdomain_scan",
+            "icmp_scan",
+            "port_scan",
+            "ssl_certificate_scan",
+            "ssl_version_scan",
+        ]
 
         contents = TemplateLoader("port_scan", {"target": ""}).load()
         self.service_discovery_signatures = list(

--- a/src/nettacker/core/module.py
+++ b/src/nettacker/core/module.py
@@ -45,7 +45,7 @@ class Module:
         self.skip_service_discovery = options.skip_service_discovery
 
         self.discovered_services = None
-        self.ignored_core_modules = ["subdomain_scan", "icmp_scan", "port_scan"]
+        self.ignored_core_modules = ["subdomain_scan", "icmp_scan", "port_scan", "ssl_certificate_scan", "ssl_version_scan"]
 
         contents = TemplateLoader("port_scan", {"target": ""}).load()
         self.service_discovery_signatures = list(

--- a/src/nettacker/core/utils/common.py
+++ b/src/nettacker/core/utils/common.py
@@ -7,6 +7,8 @@ import math
 import multiprocessing
 import random
 import re
+import socket
+import ssl
 import string
 import sys
 import time
@@ -325,39 +327,39 @@ def sort_dictionary(dictionary):
         sorted_dictionary["..."] = {}
     return sorted_dictionary
 
+
 def is_weak_hash_algo(algo):
     algo = algo.lower()
-    unsafe_algos = ["md2", "md4", "md5", "sha1"]
-    for unsafe_algo in unsafe_algos:
-        if( unsafe_algo in algo ): return True
+    for unsafe_algo in ("md2", "md4", "md5", "sha1"):
+        if unsafe_algo in algo:
+            return True
     return False
 
+
 def check_ssl_version(ssl_ver):
-    if( ssl_ver == "TLSv1.3" or ssl_ver == "TLSv1.2" ):
-        return False
-    return True
+    return ssl_ver not in {"TLSv1.2", "TLSv1.3"}
+
 
 def check_cipher_suite(host, port, timeout):
-    import socket
-    import ssl
-    unsecure_ciphers = ['AES128-GCM-SHA256',
-                        'AES256-GCM-SHA384',
-                        'AES128-SHA',
-                        'AES256-SHA',
-                        'DES-CBC3-SHA']
+    unsecure_ciphers = (
+        "AES128-GCM-SHA256",
+        "AES256-GCM-SHA384",
+        "AES128-SHA",
+        "AES256-SHA",
+        "DES-CBC3-SHA",
+    )
     bad_cipher_suite = False
     for ciphers in unsecure_ciphers:
         try:
             socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             socket_connection.settimeout(timeout)
             socket_connection.connect((host, port))
-            ssl_flag = False
         except ConnectionRefusedError:
             continue
         try:
-            socket_connection = ssl.wrap_socket(socket_connection, ciphers = ciphers)
+            socket_connection = ssl.wrap_socket(socket_connection, ciphers=ciphers)
             bad_cipher_suite = True
             break
-        except:
+        except Exception:
             continue
     return bad_cipher_suite

--- a/src/nettacker/core/utils/common.py
+++ b/src/nettacker/core/utils/common.py
@@ -324,3 +324,40 @@ def sort_dictionary(dictionary):
     if etc_flag:
         sorted_dictionary["..."] = {}
     return sorted_dictionary
+
+def is_weak_hash_algo(algo):
+    algo = algo.lower()
+    unsafe_algos = ["md2", "md4", "md5", "sha1"]
+    for unsafe_algo in unsafe_algos:
+        if( unsafe_algo in algo ): return True
+    return False
+
+def check_ssl_version(ssl_ver):
+    if( ssl_ver == "TLSv1.3" or ssl_ver == "TLSv1.2" ):
+        return False
+    return True
+
+def check_cipher_suite(host, port, timeout):
+    import socket
+    import ssl
+    unsecure_ciphers = ['AES128-GCM-SHA256',
+                        'AES256-GCM-SHA384',
+                        'AES128-SHA',
+                        'AES256-SHA',
+                        'DES-CBC3-SHA']
+    bad_cipher_suite = False
+    for ciphers in unsecure_ciphers:
+        try:
+            socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            socket_connection.settimeout(timeout)
+            socket_connection.connect((host, port))
+            ssl_flag = False
+        except ConnectionRefusedError:
+            continue
+        try:
+            socket_connection = ssl.wrap_socket(socket_connection, ciphers = ciphers)
+            bad_cipher_suite = True
+            break
+        except:
+            continue
+    return bad_cipher_suite

--- a/src/nettacker/database/models.py
+++ b/src/nettacker/database/models.py
@@ -30,7 +30,7 @@ class Report(Base):
 class TempEvents(Base):
     """
     This class defines the table schema of the reports table. Any changes to
-    the reports table need to be done here.
+    the temp_events table need to be done here.
     """
 
     __tablename__ = "temp_events"

--- a/src/nettacker/modules/scan/ssl_certificate.yaml
+++ b/src/nettacker/modules/scan/ssl_certificate.yaml
@@ -1,0 +1,37 @@
+info:
+  name: ssl_certificate_scan
+  author: Captain-T2004
+  severity: 6
+  description: check if there are any ssl_certificate vulnerabilities present 
+  reference:
+    - https://www.beyondsecurity.com/resources/vulnerabilities/ssl-certificate-expiry
+  profiles:
+    - scan
+
+payloads:
+  - library: socket
+    steps:
+      - method: ssl_certificate_scan
+        timeout: 3
+        host: "{target}"
+        ports:
+          - 21
+          - 25
+          - 110
+          - 143
+          - 443
+          - 587
+          - 990
+          - 1080
+          - 8080
+        response:
+          condition_type: or
+          conditions:
+            self_signed:
+              reverse: false
+            expired:
+              reverse: false
+            weak_signing_algo:
+              reverse: false
+            expiring_soon:
+              reverse: false

--- a/src/nettacker/modules/scan/ssl_version.yaml
+++ b/src/nettacker/modules/scan/ssl_version.yaml
@@ -28,7 +28,7 @@ payloads:
         response:
           condition_type: or
           conditions:
-            bad_cipher_suite:
+            weak_cipher_suite:
               reverse: false
-            bad_version:
+            weak_version:
               reverse: false

--- a/src/nettacker/modules/scan/ssl_version.yaml
+++ b/src/nettacker/modules/scan/ssl_version.yaml
@@ -1,0 +1,34 @@
+info:
+  name: ssl_version_scan
+  author: Captain-T2004
+  severity: 6
+  description: check if ssl version is unsafe or uses any bad ciphers.
+  reference:
+    # Need to change this
+    - https://www.beyondsecurity.com/resources/vulnerabilities/ssl-certificate-expiry
+  profiles:
+    - scan
+
+payloads:
+  - library: socket
+    steps:
+      - method: ssl_version_scan
+        timeout: 3
+        host: "{target}"
+        ports:
+          - 21
+          - 25
+          - 110
+          - 143
+          - 443
+          - 587
+          - 990
+          - 1080
+          - 8080
+        response:
+          condition_type: or
+          conditions:
+            bad_cipher_suite:
+              reverse: false
+            bad_version:
+              reverse: false

--- a/tests/core/test_socket.py
+++ b/tests/core/test_socket.py
@@ -1,0 +1,163 @@
+from unittest.mock import patch
+
+from core.lib.socket import create_tcp_socket, SocketLibrary
+
+from tests.common import TestCase
+
+
+class MockConnectionObject:
+    def __init__(self, peername, version=None):
+        self.Peername = peername
+        self.Version = version
+
+    def getpeername(self):
+        return self.Peername
+
+    def version(self):
+        return self.Version
+
+
+class Mockx509Object:
+    def __init__(self, issuer, subject, is_expired, expire_date, signing_algo):
+        self.issuer = issuer
+        self.subject = subject
+        self.expired = is_expired
+        self.expire_date = expire_date
+        self.signature_algorithm = signing_algo
+
+    def get_issuer(self):
+        return self.issuer
+
+    def get_subject(self):
+        return self.subject
+
+    def has_expired(self):
+        return self.expired
+
+    def get_notAfter(self):
+        return self.expire_date
+
+    def get_signature_algorithm(self):
+        return self.signature_algorithm
+
+
+class TestSSLMethods(TestCase):
+    @patch("socket.socket")
+    @patch("ssl.wrap_socket")
+    def test_create_tcp_socket(self, mock_wrap, mock_socket):
+        HOST = "example.com"
+        PORT = 80
+        TIMEOUT = 60
+
+        create_tcp_socket(HOST, PORT, TIMEOUT)
+        socket_instance = mock_socket.return_value
+        socket_instance.settimeout.assert_called_with(TIMEOUT)
+        socket_instance.connect.assert_called_with((HOST, PORT))
+        mock_wrap.assert_called_with(socket_instance)
+
+    @patch("core.lib.socket.check_cipher_suite")
+    @patch("core.lib.socket.create_tcp_socket")
+    def test_ssl_version_scan(self, mock_connection, mock_cipher_check):
+        library = SocketLibrary()
+        HOST = "example.com"
+        PORT = 80
+        TIMEOUT = 60
+
+        mock_connection.return_value = (MockConnectionObject(HOST, "TLSv1.3"), True)
+        mock_cipher_check.return_value = False
+        self.assertEqual(
+            library.ssl_version_scan(HOST, PORT, TIMEOUT),
+            {
+                "ssl_flag": True,
+                "service": "http",
+                "bad_version": False,
+                "ssl_version": "TLSv1.3",
+                "bad_cipher_suite": False,
+                "peer_name": "example.com",
+            },
+        )
+        mock_connection.return_value = (MockConnectionObject(HOST, "TLSv1.1"), True)
+        mock_cipher_check.return_value = True
+        self.assertEqual(
+            library.ssl_version_scan(HOST, PORT, TIMEOUT),
+            {
+                "ssl_flag": True,
+                "service": "http",
+                "bad_version": True,
+                "bad_cipher_suite": True,
+                "ssl_version": "TLSv1.1",
+                "peer_name": "example.com",
+            },
+        )
+
+        mock_connection.return_value = (MockConnectionObject(HOST), False)
+        self.assertEqual(
+            library.ssl_version_scan(HOST, PORT, TIMEOUT),
+            {
+                "ssl_flag": False,
+                "service": "http",
+                "peer_name": "example.com",
+            },
+        )
+
+    @patch("core.lib.socket.create_tcp_socket")
+    @patch("core.lib.socket.crypto.load_certificate")
+    @patch("core.lib.socket.ssl.get_server_certificate")
+    def test_ssl_certificate_scan(self, mock_certificate, mock_x509, mock_connection):
+        library = SocketLibrary()
+        HOST = "example.com"
+        PORT = 80
+        TIMEOUT = 60
+
+        mock_connection.return_value = (MockConnectionObject(HOST, "TLSv1.3"), True)
+        mock_x509.return_value = Mockx509Object(
+            is_expired=False,
+            issuer="test_issuer",
+            subject="test_subject",
+            signing_algo="test_algo",
+            expire_date=b"20250619153045Z",
+        )
+        self.assertEqual(
+            library.ssl_certificate_scan(HOST, PORT, TIMEOUT),
+            {
+                "expired": False,
+                "ssl_flag": True,
+                "service": "http",
+                "self_signed": False,
+                "expiring_soon": False,
+                "weak_signing_algo": False,
+                "peer_name": "example.com",
+            },
+        )
+
+        mock_connection.return_value = (MockConnectionObject(HOST), False)
+        self.assertEqual(
+            library.ssl_certificate_scan(HOST, PORT, TIMEOUT),
+            {
+                "service": "http",
+                "ssl_flag": False,
+                "peer_name": "example.com",
+            },
+        )
+        mock_certificate.assert_called_with((HOST, PORT))
+
+        mock_connection.return_value = (MockConnectionObject(HOST, "TLSv1.3"), True)
+        mock_x509.return_value = Mockx509Object(
+            is_expired=True,
+            issuer="test_issuer_subject",
+            subject="test_issuer_subject",
+            signing_algo="sha1",
+            expire_date=b"20240619153045Z",
+        )
+        self.assertEqual(
+            library.ssl_certificate_scan(HOST, PORT, TIMEOUT),
+            {
+                "expired": True,
+                "ssl_flag": True,
+                "service": "http",
+                "self_signed": True,
+                "expiring_soon": True,
+                "weak_signing_algo": True,
+                "peer_name": "example.com",
+            },
+        )

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,3 +1,4 @@
+import ssl
 from unittest.mock import patch
 
 from core.utils import common as utils
@@ -55,25 +56,28 @@ class TestUtils(TestCase):
 
     def test_is_weak_hash_algo(self):
         for algo in ("md2", "md4", "md5", "sha1"):
-            self.assertEqual(utils.is_weak_hash_algo(algo), True)
-        self.assertEqual(utils.is_weak_hash_algo("test_aglo"), False)
+            self.assertTrue(utils.is_weak_hash_algo(algo))
+        self.assertFalse(utils.is_weak_hash_algo("test_aglo"))
 
-    def test_check_ssl_version(self):
+    def test_is_weak_ssl_version(self):
         for ver in {"TLSv1.2", "TLSv1.3"}:
-            self.assertEqual(utils.check_ssl_version(ver), False)
-        self.assertEqual(utils.check_ssl_version("test_version"), True)
+            self.assertFalse(utils.is_weak_ssl_version(ver))
+        self.assertTrue(utils.is_weak_ssl_version("test_version"))
 
     @patch("socket.socket")
-    @patch("ssl.wrap_socket")
-    def test_check_cipher_suite(self, mock_wrap, mock_socket):
+    @patch("ssl.create_default_context")
+    def test_is_weak_cipher_suite(self, mock_context, mock_socket):
         HOST = "example.com"
         PORT = 80
         TIMEOUT = 60
 
         socket_instance = mock_socket.return_value
-        self.assertEqual(utils.check_cipher_suite(HOST, PORT, TIMEOUT), True)
+        context_instance = mock_context.return_value
+
+        self.assertTrue(utils.is_weak_cipher_suite(HOST, PORT, TIMEOUT))
+        context_instance.wrap_socket.assert_called_with(socket_instance)
         socket_instance.settimeout.assert_called_with(TIMEOUT)
         socket_instance.connect.assert_called_with((HOST, PORT))
 
-        mock_wrap.side_effect = Exception()
-        self.assertEqual(utils.check_cipher_suite(HOST, PORT, TIMEOUT), False)
+        context_instance.wrap_socket.side_effect = ssl.SSLError
+        self.assertFalse(utils.is_weak_cipher_suite(HOST, PORT, TIMEOUT))

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -52,3 +52,28 @@ class TestUtils(TestCase):
                 )
 
             self.assertEqual(utils.select_maximum_cpu_core("invalid"), 1)
+
+    def test_is_weak_hash_algo(self):
+        for algo in ("md2", "md4", "md5", "sha1"):
+            self.assertEqual(utils.is_weak_hash_algo(algo), True)
+        self.assertEqual(utils.is_weak_hash_algo("test_aglo"), False)
+
+    def test_check_ssl_version(self):
+        for ver in {"TLSv1.2", "TLSv1.3"}:
+            self.assertEqual(utils.check_ssl_version(ver), False)
+        self.assertEqual(utils.check_ssl_version("test_version"), True)
+
+    @patch("socket.socket")
+    @patch("ssl.wrap_socket")
+    def test_check_cipher_suite(self, mock_wrap, mock_socket):
+        HOST = "example.com"
+        PORT = 80
+        TIMEOUT = 60
+
+        socket_instance = mock_socket.return_value
+        self.assertEqual(utils.check_cipher_suite(HOST, PORT, TIMEOUT), True)
+        socket_instance.settimeout.assert_called_with(TIMEOUT)
+        socket_instance.connect.assert_called_with((HOST, PORT))
+
+        mock_wrap.side_effect = Exception()
+        self.assertEqual(utils.check_cipher_suite(HOST, PORT, TIMEOUT), False)


### PR DESCRIPTION
#### Checklist


FIX: This now handles the case when the response from the scanning method is None(TCP connection failed or returned None)
#### Your development environment
- OS: `Kali GNU/Linux Rolling x86_64`
- OS Version: `6.8.11`
- Python Version: `3.11`
